### PR TITLE
feat: prefer a region for transferring data from

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -4,3 +4,6 @@ DYNAMO_REGION=us-west-2
 DYNAMO_TABLE=<table name here>
 # (optional) CSV of S3 regions of buckets that CAR files are stored in
 S3_REGIONS=us-east-2,us-west-2
+# (optional) preferred region to fetch data from - typically same place as
+# where the lambda is running
+PREFER_REGION=us-west-2

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -17,6 +17,10 @@ DYNAMO_TABLE=prod-ep-v1-blocks-cars-position
 
 # CSV S3 regions of buckets that CAR files are stored in (optional)
 S3_REGIONS=us-east-2,us-west-2
+
+# (optional) preferred region to fetch data from - typically same place as
+# where the lambda is running
+PREFER_REGION=us-west-2
 ```
 
 Run the NodeJS server:

--- a/packages/core/src/bindings.d.ts
+++ b/packages/core/src/bindings.d.ts
@@ -10,6 +10,7 @@ export interface Environment {
   DYNAMO_REGION: string
   DYNAMO_TABLE: string
   S3_REGIONS: string
+  PREFER_REGION: string
 }
 
 export interface DynamoContext extends Context {

--- a/packages/core/src/lib/block-index.js
+++ b/packages/core/src/lib/block-index.js
@@ -13,6 +13,7 @@ export class DynamoIndex {
   #client
   #table
   #max
+  #preferRegion
 
   /**
    * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} client 
@@ -20,11 +21,14 @@ export class DynamoIndex {
    * @param {object} [options]
    * @param {number} [options.maxEntries] Max entries to return when multiple
    * CAR files contain the same block.
+   * @param {string} [options.preferRegion] Preferred region to place first in
+   * results.
    */
   constructor (client, table, options) {
     this.#client = client
     this.#table = table
     this.#max = options?.maxEntries ?? 5
+    this.#preferRegion = options?.preferRegion
   }
 
   /**
@@ -46,10 +50,20 @@ export class DynamoIndex {
       })
       return await this.#client.send(command)
     }, { minTimeout: 100, onFailedAttempt: err => console.warn(`failed DynamoDB request for: ${cid}`, err) })
-    return (res.Items ?? []).map(item => {
+    const items = (res.Items ?? []).map(item => {
       const { carpath, offset, length } = unmarshall(item)
       const [region, bucket, ...rest] = carpath.split('/')
       return { region, bucket, key: rest.join('/'), offset, length }
     })
+    if (this.#preferRegion) {
+      const region = this.#preferRegion
+      items.sort((a, b) => {
+        if (a.region === region && b.region !== region) return -1
+        if (a.region !== region && b.region === region) return 1
+        return 0
+      })
+      console.log(items)
+    }
+    return items
   }
 }

--- a/packages/core/src/lib/block-index.js
+++ b/packages/core/src/lib/block-index.js
@@ -55,15 +55,15 @@ export class DynamoIndex {
       const [region, bucket, ...rest] = carpath.split('/')
       return { region, bucket, key: rest.join('/'), offset, length }
     })
-    if (this.#preferRegion) {
-      const region = this.#preferRegion
+    const region = this.#preferRegion
+    if (region) {
       items.sort((a, b) => {
         if (a.region === region && b.region !== region) return -1
         if (a.region !== region && b.region === region) return 1
         return 0
       })
-      console.log(items)
     }
+    console.log(cid.toString(), items)
     return items
   }
 }

--- a/packages/core/src/lib/block-index.js
+++ b/packages/core/src/lib/block-index.js
@@ -63,7 +63,6 @@ export class DynamoIndex {
         return 0
       })
     }
-    console.log(cid.toString(), items)
     return items
   }
 }

--- a/packages/core/src/lib/blockstore.js
+++ b/packages/core/src/lib/blockstore.js
@@ -107,7 +107,7 @@ export class BatchingDynamoBlockstore extends DynamoBlockstore {
       const blocks = pendingBlocks.get(key)
       if (!blocks) return
       console.log(`got wanted block ${cid} (${pendingBlocks.size} remaining)`)
-      const block = { cid, bytes }
+      const block = { cid, bytes: bytes.slice() }
       blocks.forEach(b => b.resolve(block))
       pendingBlocks.delete(key)
     }

--- a/packages/core/src/lib/blockstore.js
+++ b/packages/core/src/lib/blockstore.js
@@ -107,7 +107,7 @@ export class BatchingDynamoBlockstore extends DynamoBlockstore {
       const blocks = pendingBlocks.get(key)
       if (!blocks) return
       console.log(`got wanted block ${cid} (${pendingBlocks.size} remaining)`)
-      const block = { cid, bytes: bytes.slice() }
+      const block = { cid, bytes }
       blocks.forEach(b => b.resolve(block))
       pendingBlocks.delete(key)
     }
@@ -122,6 +122,7 @@ export class BatchingDynamoBlockstore extends DynamoBlockstore {
       const range = `bytes=${batch[0].offset}-${batch[batch.length - 1].offset + batch[batch.length - 1].length - 1}`
 
       console.log(`fetching ${batch.length} blocks from s3://${region}/${bucket}/${key} (${range})`)
+      console.log(batch)
       const s3Client = this._buckets[region]
       if (!s3Client) break
 

--- a/packages/core/src/lib/blockstore.js
+++ b/packages/core/src/lib/blockstore.js
@@ -174,7 +174,10 @@ export class BatchingDynamoBlockstore extends DynamoBlockstore {
   async get (cid) {
     // console.log(`get ${cid}`)
     const idxEntries = await this._idx.get(cid)
-    if (!idxEntries.length) return
+    if (!idxEntries.length) {
+      console.warn(`dynamo has not indexed: ${cid}`)
+      return
+    }
 
     this.#batcher.add(cid, idxEntries)
     const key = mhToKey(cid.multihash.bytes)

--- a/packages/core/src/lib/blockstore.js
+++ b/packages/core/src/lib/blockstore.js
@@ -122,7 +122,6 @@ export class BatchingDynamoBlockstore extends DynamoBlockstore {
       const range = `bytes=${batch[0].offset}-${batch[batch.length - 1].offset + batch[batch.length - 1].length - 1}`
 
       console.log(`fetching ${batch.length} blocks from s3://${region}/${bucket}/${key} (${range})`)
-      console.log(batch)
       const s3Client = this._buckets[region]
       if (!s3Client) break
 
@@ -175,10 +174,7 @@ export class BatchingDynamoBlockstore extends DynamoBlockstore {
   async get (cid) {
     // console.log(`get ${cid}`)
     const idxEntries = await this._idx.get(cid)
-    if (!idxEntries.length) {
-      console.warn(`dynamo has not indexed: ${cid}`)
-      return
-    }
+    if (!idxEntries.length) return
 
     this.#batcher.add(cid, idxEntries)
     const key = mhToKey(cid.multihash.bytes)

--- a/packages/core/src/lib/blockstore.js
+++ b/packages/core/src/lib/blockstore.js
@@ -21,11 +21,14 @@ export class DynamoBlockstore {
    * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient 
    * @param {string} dynamoTable
    * @param {import('../bindings').RegionalS3Clients} s3Clients
+   * @param {object} [options]
+   * @param {string} [options.preferRegion] Preferred region to fetch data
+   * from, typically the same region as where the service is running.
    */
-  constructor (dynamoClient, dynamoTable, s3Clients) {
+  constructor (dynamoClient, dynamoTable, s3Clients, options) {
     this._buckets = s3Clients
     /** @type {import('./block-index').BlockIndex} */
-    this._idx = new DynamoIndex(dynamoClient, dynamoTable)
+    this._idx = new DynamoIndex(dynamoClient, dynamoTable, options)
   }
 
   /** @param {import('multiformats').UnknownLink} cid */

--- a/packages/core/src/middleware.js
+++ b/packages/core/src/middleware.js
@@ -70,7 +70,7 @@ function getAwsCredentials (env) {
  */
 export function withDagula (handler) {
   return async (request, env, ctx) => {
-    const blockstore = new BatchingDynamoBlockstore(ctx.dynamoClient, ctx.dynamoTable, ctx.s3Clients)
+    const blockstore = new BatchingDynamoBlockstore(ctx.dynamoClient, ctx.dynamoTable, ctx.s3Clients, { preferRegion: env.PREFER_REGION })
     const dagula = new Dagula(blockstore)
     return handler(request, env, { ...ctx, dagula })
   }

--- a/packages/lambda/src/autobahn.js
+++ b/packages/lambda/src/autobahn.js
@@ -62,7 +62,8 @@ export async function getIpfs (evt, res) {
     DEBUG: process.env.DEBUG ?? 'false',
     DYNAMO_REGION: process.env.DYNAMO_REGION,
     DYNAMO_TABLE: process.env.DYNAMO_TABLE,
-    S3_REGIONS: process.env.S3_REGIONS
+    S3_REGIONS: process.env.S3_REGIONS,
+    PREFER_REGION: process.env.AWS_REGION
   }
   const ctx = { waitUntil: () => {} }
   // @ts-expect-error


### PR DESCRIPTION
Adds an env var `PREFER_REGION` which is set to `AWS_REGION`.

It's used to order index results, ordering items from the preferred region before other results.

This allows autobahn to avoid egress changes when transferring data stored in two different regions (when one of the regions is the region the service is running in).