### PR TITLE
chore: set `--invoke-mode RESPONSE_STREAM` on lambda

### DIFF
--- a/seed.yml
+++ b/seed.yml
@@ -9,7 +9,7 @@ before_compile:
 after_deploy:
   - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
   - unzip awscliv2.zip
-  - ./aws/install
+  - ./aws/install --update
   - echo "export STACK_NAME=${SEED_STAGE_NAME}-autobahn-API" >> $BASH_ENV
   - echo $STACK_NAME
   - echo "export FUNCTION_NAME=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`functionName`].OutputValue | [0]' --output text)" >> $BASH_ENV

--- a/seed.yml
+++ b/seed.yml
@@ -2,3 +2,12 @@
 before_compile:
   - n 18.16.0
   - npm ci
+
+# set --invoke-mode RESPONSE_STREAM on lambda fn
+# see: https://seed.run/docs/adding-a-build-spec#reference-cloudformation-output
+after_deploy:
+  - echo "export STACK_NAME=${SEED_STAGE_NAME}-autobahn-API" >> $BASH_ENV
+  - echo $STACK_NAME
+  - echo "export FUNCTION_NAME=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`functionName`].OutputValue | [0]' --output text)" >> $BASH_ENV
+  - echo $FUNCTION_NAME
+  - aws lambda update-function-url-config --function-name $FUNCTION_NAME --invoke-mode RESPONSE_STREAM

--- a/seed.yml
+++ b/seed.yml
@@ -4,8 +4,12 @@ before_compile:
   - npm ci
 
 # set --invoke-mode RESPONSE_STREAM on lambda fn
+# note: gotta update the aws cli first as the one with seed.run doesn't support --invoke-mode yet.
 # see: https://seed.run/docs/adding-a-build-spec#reference-cloudformation-output
 after_deploy:
+  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  - unzip awscliv2.zip
+  - ./aws/install
   - echo "export STACK_NAME=${SEED_STAGE_NAME}-autobahn-API" >> $BASH_ENV
   - echo $STACK_NAME
   - echo "export FUNCTION_NAME=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`functionName`].OutputValue | [0]' --output text)" >> $BASH_ENV

--- a/stacks/api.js
+++ b/stacks/api.js
@@ -120,6 +120,7 @@ export function API ({ stack, app }) {
   stack.addOutputs({
     url: `https://${dns.domainName}`,
     functionUrl: fun.url,
+    functionName: fun.functionName,
     cloudfrontUrl: `https://${dist.distributionDomainName}`
   })
 }


### PR DESCRIPTION
use seed.yml to call the aws cli to extract the function name from the cloudformation output and then again to set `--invoke-mode RESPONSE_STREAM` config on that function... otherwise we have to remember to manually configure it for every PR build and everything fails if we forget, so it's worth landing this workaround while sst / aws-cdk does not yet support configuring this.

see: https://seed.run/docs/adding-a-build-spec#reference-cloudformation-output
see: https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html#config-rs-invoke-furls

fixes:

License: MIT